### PR TITLE
Rewrite to support Frigate 0.14, NX Witness REST API v3, MQTT authentication and self signed SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,29 +11,4 @@ Creates a bookmark in NX Witness whenever a specifed object is detected by Friga
 
 # Configuration
 
-Configuration sample:
-
- ```
-{
-    "nxwitness": {
-        "host": "192.168.0.99",
-        "port": "7001",
-        "username": "admin",
-        "password": "YOURPASSWORD"
-    },
-    "mqtt": {
-        "host": "192.168.0.100",
-        "topic": "frigate"
-    },
-    "cameraMap": [
-        {
-            "frigateName": "camera1",
-            "nxwId": "00000000-0000-0000-0000-000000000000"
-        },
-        {
-            "frigateName": "camera2",
-            "nxwId": "00000000-0000-0000-0000-000000000000"
-        }
-    ]
-}
- ```
+See config.example.json for a configuration example

--- a/config.example.json
+++ b/config.example.json
@@ -7,7 +7,9 @@
     },
     "mqtt": {
         "host": "192.168.0.100",
-        "topic": "frigate"
+        "topic": "frigate",
+        "username": "admin",
+        "password": "YOURPASSWORD"
     },
     "cameraMap": [
         {

--- a/index.js
+++ b/index.js
@@ -1,85 +1,70 @@
-//fs = require('fs');
+const https = require("https");
 const mqtt = require('mqtt');
 const axios = require('axios');
-const { v4: uuidv4 } = require('uuid');
 
 // Load configuration
 var config = require('/config/config.json');
 
 // Setup MQTT connection
-var client  = mqtt.connect('mqtt://'+ config.mqtt.host);
+console.log('Trying to connect to MQTT...');
+var client  = mqtt.connect('mqtt://'+ config.mqtt.host, {
+  port: 1883,
+  username: config.mqtt.username,
+  password: config.mqtt.password
+});
+
 client.on('connect', function () {
-    client.subscribe(config.mqtt.topic +'/#', function (err) {
-        console.log('Subscribed to MQTT topic: '+ config.mqtt.topic);
-    });
+  client.subscribe(config.mqtt.topic +'/events/#', function (err) {
+    console.log('Subscribed to MQTT topic: '+ config.mqtt.topic);
+  });
 });
 
 // On receive MQTT message
 client.on('message', function (topic, message) {
-    try {
-        var topicPath = topic.split('/');
+  try {
+    var eventData = JSON.parse(message);
 
-        // Skip initial status message
-        if(topicPath[1] != 'available') {
-            var camera = topicPath[1];
-            var mappedCamera = config.cameraMap.find(i => i.frigateName == camera);
+    // Only hanle 'end' event
+    if(eventData.type == 'end' && !eventData.after.false_positive) {
 
-            // Only handle events from mapped cameras
-            if(mappedCamera !== undefined) {
-            
-                // Only handle 'events'
-                if(topicPath[2] == 'events') {
-                    var eventData = JSON.parse(message);
+      var camera = eventData.after.camera;
+      var mappedCamera = config.cameraMap.find(i => i.frigateName == camera);
 
-                    // Only hanle 'end' event
-                    if(topicPath[3] == 'end') {
-                        
-                        // Skip false positives
-                        if(!eventData.false_positive) {
+      if(mappedCamera !== undefined) {
 
-                            // Gather event data
-                            var event = {
-                                guid: uuidv4(),
-                                cameraId: mappedCamera.nxwId,
-                                name: eventData.label,
-                                startTimeMs: Math.round(eventData.start_time * 1000),
-                                durationMs: Math.round((eventData.end_time - eventData.start_time) * 1000),
-                                tag: 'frigate'
-                            };
+        // Gather event data
+        var event = {
+           name: eventData.after.label,
+           startTimeMs: Math.round(eventData.after.start_time * 1000),
+           durationMs: Math.round((eventData.after.end_time - eventData.after.start_time) * 1000),
+           tag: 'frigate'
+        };
 
-                            // Send data to NX Witness
-                            axios.request({
-                                method: 'get',
-                                url: 'http://'+ config.nxwitness.host +':'+ config.nxwitness.port +'/ec2/bookmarks/add',
-                                auth: {
-                                    username: config.nxwitness.username,
-                                    password: config.nxwitness.password
-                                },
-                                responseType: 'json',
-                                params: Object.assign({ format: 'json' }, event)
-                            })
-                            .then(function (response) {
-                                console.log('Notified NX Witness of "'+ event.name +'" event on "'+ camera +'"');
-                            })
-                            .catch(function (error) {
-                                console.log('Something went wrong trying to notify NX Witness');
-                                console.log(error);
-                            });
-
-                        }
-                        else {
-                            console.log('Skipping false positive event from: '+ camera);
-                        }
-                    }
-                }            
-            }
-            else {
-                console.log('Received event from unconfigured camera: '+ camera);
-            }
-        }
+        // Send data to NX Witness
+        axios.request({
+          httpsAgent: new https.Agent({ rejectUnauthorized: false }),
+            method: 'post',
+            url: 'https://'+ config.nxwitness.host +':'+ config.nxwitness.port +'/rest/v3/devices/' + mappedCamera.nxwId + '/bookmarks',
+            auth: {
+              username: config.nxwitness.username,
+              password: config.nxwitness.password
+            },
+            responseType: 'json',
+            params: {
+              '_local' : true
+            },
+            data: Object.assign({ format: 'json' }, event)
+          })
+          .then(function (response) {
+            console.log('Notified NX Witness of "'+ event.name +'" event on "'+ camera +'"');
+          })
+          .catch(function (error) {
+           console.log('An error occured when trying to notify NX Witness:' + error);
+          });
+      }
     }
-    catch (e) {
-        console.log('Something went wrong');
-        console.log(e);
-    }
+  }
+  catch (e) {
+    console.log('An error occured: ' + e);
+  }
 });


### PR DESCRIPTION
I rewrote index.js to support:
- MQTT authentication
- Connecting with the NX Witness server on SSL, using self signed certificates
- Support of Frigate 0.14 (and probably a few earlier releases)
- Support of NX Witness REST API v3, the one that was used is deprecated